### PR TITLE
docs/mc-20995-add-service-name-to-aws-articles

### DIFF
--- a/en/aws-compute-service/aws-add_a_subnetwork.md
+++ b/en/aws-compute-service/aws-add_a_subnetwork.md
@@ -1,8 +1,9 @@
 ---
-title: "Add a subnetwork"
-slug: aws-add-a-subnetwork
+author: "AWS: Add a subnetwork"
+publisher: aws-add-a-subnetwork
 ---
 
+# AWS: Add a subnetwork
 
 ## About this task
 

--- a/en/aws-compute-service/aws-add_a_subnetwork.md
+++ b/en/aws-compute-service/aws-add_a_subnetwork.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Add a subnetwork"
-publisher: aws-add-a-subnetwork
+title: "AWS: Add a subnetwork"
+slug: aws-add-a-subnetwork
 ---
 
-# AWS: Add a subnetwork
 
 ## About this task
 

--- a/en/aws-compute-service/aws-add_a_volume.md
+++ b/en/aws-compute-service/aws-add_a_volume.md
@@ -1,8 +1,9 @@
 ---
-title: "Add a volume"
-slug: aws-add-a-volume
+author: "AWS: Add a volume"
+publisher: aws-add-a-volume
 ---
 
+# AWS: Add a volume
 
 ## About this task
 

--- a/en/aws-compute-service/aws-add_a_volume.md
+++ b/en/aws-compute-service/aws-add_a_volume.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Add a volume"
-publisher: aws-add-a-volume
+title: "AWS: Add a volume"
+slug: aws-add-a-volume
 ---
 
-# AWS: Add a volume
 
 ## About this task
 

--- a/en/aws-compute-service/aws-add_a_vpc.md
+++ b/en/aws-compute-service/aws-add_a_vpc.md
@@ -1,8 +1,9 @@
 ---
-title: "Add a VPC"
-slug: aws-add-a-vpc
+author: "AWS: Add a VPC"
+publisher: aws-add-a-vpc
 ---
 
+# AWS: Add a VPC
 
 ## About this task
 

--- a/en/aws-compute-service/aws-add_a_vpc.md
+++ b/en/aws-compute-service/aws-add_a_vpc.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Add a VPC"
-publisher: aws-add-a-vpc
+title: "AWS: Add a VPC"
+slug: aws-add-a-vpc
 ---
 
-# AWS: Add a VPC
 
 ## About this task
 

--- a/en/aws-compute-service/aws-add_an_instance.md
+++ b/en/aws-compute-service/aws-add_an_instance.md
@@ -1,8 +1,9 @@
 ---
-title: "Add an instance"
-slug: aws-add-an-instance
+author: "AWS: Add an instance"
+publisher: aws-add-an-instance
 ---
 
+# AWS: Add an instance
 
 ## About this task
 

--- a/en/aws-compute-service/aws-add_an_instance.md
+++ b/en/aws-compute-service/aws-add_an_instance.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Add an instance"
-publisher: aws-add-an-instance
+title: "AWS: Add an instance"
+slug: aws-add-an-instance
 ---
 
-# AWS: Add an instance
 
 ## About this task
 

--- a/en/aws-compute-service/aws-amis.md
+++ b/en/aws-compute-service/aws-amis.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: AMIs"
-publisher: aws-amis
+title: "AWS: AMIs"
+slug: aws-amis
 ---
 
-# AWS: AMIs
 
 Amazon Web Services provides pre-defined images, called Amazon Machine Images, to be used when creating new instances on the AWS platform. At a minimum, an AMI contains the operating system required to boot a new virtual machine. There is a wide variety of AMIs to choose from, and some may contain software applications already installed for your convenience.
 

--- a/en/aws-compute-service/aws-amis.md
+++ b/en/aws-compute-service/aws-amis.md
@@ -1,8 +1,9 @@
 ---
-title: "AMIs"
-slug: aws-amis
+author: "AWS: AMIs"
+publisher: aws-amis
 ---
 
+# AWS: AMIs
 
 Amazon Web Services provides pre-defined images, called Amazon Machine Images, to be used when creating new instances on the AWS platform. At a minimum, an AMI contains the operating system required to boot a new virtual machine. There is a wide variety of AMIs to choose from, and some may contain software applications already installed for your convenience.
 
@@ -10,5 +11,5 @@ Your CloudMC administrator has provided a set of AMIs that you may select from w
 
 AMIs are listed on the **Add instance** page, under the **Choose an image** section.
 
-**Parent topic:**[Compute](aws-compute.md)
+**Parent topic:**[AWS: Compute](aws-compute.md)
 

--- a/en/aws-compute-service/aws-buckets.md
+++ b/en/aws-compute-service/aws-buckets.md
@@ -1,10 +1,11 @@
 ---
-title: "Buckets"
-slug: aws-buckets
+author: "AWS: Buckets"
+publisher: aws-buckets
 ---
 
+# AWS: Buckets
 
-![A screenshot of the contents of an AWS bucket, with numbered dots indicating features of interest](/assets/aws-objectstorage-filelist-numdots-en.png)
+![A screenshot of the contents of an AWS bucket, with numbered dots indicating features of interest](aws-objectstorage-filelist-numdots-en.png "List of objects in an AWS bucket")
 
 1.  **List of objects**
 
@@ -37,5 +38,5 @@ Each bucket has a name, an AWS region, and access permissions.
 
 **Attention:** Once a bucket has been created, its name and region cannot be changed.
 
-**Parent topic:**[Object storage](aws-object_storage.md)
+**Parent topic:**[AWS: Object storage](aws-object_storage.md)
 

--- a/en/aws-compute-service/aws-buckets.md
+++ b/en/aws-compute-service/aws-buckets.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Buckets"
-publisher: aws-buckets
+title: "AWS: Buckets"
+slug: aws-buckets
 ---
 
-# AWS: Buckets
 
 ![A screenshot of the contents of an AWS bucket, with numbered dots indicating features of interest](aws-objectstorage-filelist-numdots-en.png "List of objects in an AWS bucket")
 

--- a/en/aws-compute-service/aws-buckets.md
+++ b/en/aws-compute-service/aws-buckets.md
@@ -4,7 +4,7 @@ slug: aws-buckets
 ---
 
 
-![A screenshot of the contents of an AWS bucket, with numbered dots indicating features of interest](aws-objectstorage-filelist-numdots-en.png "List of objects in an AWS bucket")
+![A screenshot of the contents of an AWS bucket, with numbered dots indicating features of interest](aws-objectstorage-filelist-numdots-en.png)
 
 1.  **List of objects**
 

--- a/en/aws-compute-service/aws-compute.md
+++ b/en/aws-compute-service/aws-compute.md
@@ -1,10 +1,11 @@
 ---
-title: "Compute"
-slug: aws-compute
+author: "AWS: Compute"
+publisher: aws-compute
 ---
 
+# AWS: Compute
 
-![A screenshot of the AWS Compute instances page, with numbered dots indicating features of interest](/assets/aws-compute-instancelist-numdots-en.png)
+![A screenshot of the AWS Compute instances page, with numbered dots indicating features of interest](aws-compute-instancelist-numdots-en.png "List of AWS compute instances")
 
 1.  **List of instances**
 
@@ -27,10 +28,10 @@ slug: aws-compute
     Each entry in the instance list has a Hidden Actions menu. Click on the Hidden Actions menu to access a list of frequently-used operations for the instance.
 
 
--   **[Instances](aws-instances.md)**  
+-   **[AWS: Instances](aws-instances.md)**  
 
--   **[AMIs](aws-amis.md)**  
+-   **[AWS: AMIs](aws-amis.md)**  
 
--   **[Volumes](aws-volumes.md)**  
+-   **[AWS: Volumes](aws-volumes.md)**  
 
 

--- a/en/aws-compute-service/aws-compute.md
+++ b/en/aws-compute-service/aws-compute.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Compute"
-publisher: aws-compute
+title: "AWS: Compute"
+slug: aws-compute
 ---
 
-# AWS: Compute
 
 ![A screenshot of the AWS Compute instances page, with numbered dots indicating features of interest](aws-compute-instancelist-numdots-en.png "List of AWS compute instances")
 

--- a/en/aws-compute-service/aws-compute.md
+++ b/en/aws-compute-service/aws-compute.md
@@ -4,7 +4,7 @@ slug: aws-compute
 ---
 
 
-![A screenshot of the AWS Compute instances page, with numbered dots indicating features of interest](aws-compute-instancelist-numdots-en.png "List of AWS compute instances")
+![A screenshot of the AWS Compute instances page, with numbered dots indicating features of interest](aws-compute-instancelist-numdots-en.png)
 
 1.  **List of instances**
 

--- a/en/aws-compute-service/aws-instances.md
+++ b/en/aws-compute-service/aws-instances.md
@@ -1,8 +1,9 @@
 ---
-title: "Instances"
-slug: aws-instances
+author: "AWS: Instances"
+publisher: aws-instances
 ---
 
+# AWS: Instances
 
 Similar to other cloud platforms, AWS provides you with the infrastructure to run virtual machines. These virtual machines are referred to as instances. An instance is based on a pre-defined image called an **[AMI](aws-amis.md)**, which cannot be changed once an instance is deployed. Different sets of specifications are grouped together as instance types. Each instance type is a bundle of various sizes of vCPU, memory, and a root storage volume. For more details, see [Amazon EC2 Instance Types](https://aws.amazon.com/ec2/instance-types/) in the AWS documentation.
 
@@ -16,5 +17,5 @@ To log into an instance, use the SSH key pair that is created automatically upon
 
 Instances are listed under the **Compute** tab of your AWS environment, in the **Instances** section.
 
-**Parent topic:**[Compute](aws-compute.md)
+**Parent topic:**[AWS: Compute](aws-compute.md)
 

--- a/en/aws-compute-service/aws-instances.md
+++ b/en/aws-compute-service/aws-instances.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Instances"
-publisher: aws-instances
+title: "AWS: Instances"
+slug: aws-instances
 ---
 
-# AWS: Instances
 
 Similar to other cloud platforms, AWS provides you with the infrastructure to run virtual machines. These virtual machines are referred to as instances. An instance is based on a pre-defined image called an **[AMI](aws-amis.md)**, which cannot be changed once an instance is deployed. Different sets of specifications are grouped together as instance types. Each instance type is a bundle of various sizes of vCPU, memory, and a root storage volume. For more details, see [Amazon EC2 Instance Types](https://aws.amazon.com/ec2/instance-types/) in the AWS documentation.
 

--- a/en/aws-compute-service/aws-networking.md
+++ b/en/aws-compute-service/aws-networking.md
@@ -4,7 +4,7 @@ slug: aws-networking
 ---
 
 
-![A screenshot of the AWS Networking page, listing all VPCs, with numbered dots indicating features of interest](aws-compute-vpclist-numdots-en.png "List of AWS VPCs")
+![A screenshot of the AWS Networking page, listing all VPCs, with numbered dots indicating features of interest](aws-compute-vpclist-numdots-en.png)
 
 1.  **List of VPCs**
 

--- a/en/aws-compute-service/aws-networking.md
+++ b/en/aws-compute-service/aws-networking.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Networking"
-publisher: aws-networking
+title: "AWS: Networking"
+slug: aws-networking
 ---
 
-# AWS: Networking
 
 ![A screenshot of the AWS Networking page, listing all VPCs, with numbered dots indicating features of interest](aws-compute-vpclist-numdots-en.png "List of AWS VPCs")
 

--- a/en/aws-compute-service/aws-networking.md
+++ b/en/aws-compute-service/aws-networking.md
@@ -1,10 +1,11 @@
 ---
-title: "Networking"
-slug: aws-networking
+author: "AWS: Networking"
+publisher: aws-networking
 ---
 
+# AWS: Networking
 
-![A screenshot of the AWS Networking page, listing all VPCs, with numbered dots indicating features of interest](/assets/aws-compute-vpclist-numdots-en.png)
+![A screenshot of the AWS Networking page, listing all VPCs, with numbered dots indicating features of interest](aws-compute-vpclist-numdots-en.png "List of AWS VPCs")
 
 1.  **List of VPCs**
 
@@ -35,8 +36,10 @@ slug: aws-networking
     Click on the gear icon to navigate directly to that feature.
 
 
--   **[VPCs](aws-vpcs.md)**  
+-   **[AWS: VPCs](aws-vpcs.md)**  
 
--   **[Subnetworks](aws-subnetworks.md)**  
+-   **[AWS: Subnetworks](aws-subnetworks.md)**  
+
+-   **[AWS: Security groups](aws-security_groups.md)**  
 
 

--- a/en/aws-compute-service/aws-object_storage.md
+++ b/en/aws-compute-service/aws-object_storage.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Object storage"
-publisher: aws-object-storage
+title: "AWS: Object storage"
+slug: aws-object-storage
 ---
 
-# AWS: Object storage
 
 ![A screenshot of the AWS Object Storage buckets page, with numbered dots indicating features of interest](aws-objectstorage-bucketlist-numdots-en.png "List of AWS object storage buckets")
 

--- a/en/aws-compute-service/aws-object_storage.md
+++ b/en/aws-compute-service/aws-object_storage.md
@@ -1,10 +1,11 @@
 ---
-title: "Object storage"
-slug: aws-object-storage
+author: "AWS: Object storage"
+publisher: aws-object-storage
 ---
 
+# AWS: Object storage
 
-![A screenshot of the AWS Object Storage buckets page, with numbered dots indicating features of interest](/assets/aws-objectstorage-bucketlist-numdots-en.png)
+![A screenshot of the AWS Object Storage buckets page, with numbered dots indicating features of interest](aws-objectstorage-bucketlist-numdots-en.png "List of AWS object storage buckets")
 
 1.  **List of buckets**
 
@@ -31,6 +32,6 @@ slug: aws-object-storage
     Each entry in the bucket list has a Hidden Actions menu. Click on the Hidden Actions menu to access a list of frequently-used operations for the bucket.
 
 
--   **[Buckets](aws-buckets.md)**  
+-   **[AWS: Buckets](aws-buckets.md)**  
 
 

--- a/en/aws-compute-service/aws-object_storage.md
+++ b/en/aws-compute-service/aws-object_storage.md
@@ -4,7 +4,7 @@ slug: aws-object-storage
 ---
 
 
-![A screenshot of the AWS Object Storage buckets page, with numbered dots indicating features of interest](aws-objectstorage-bucketlist-numdots-en.png "List of AWS object storage buckets")
+![A screenshot of the AWS Object Storage buckets page, with numbered dots indicating features of interest](aws-objectstorage-bucketlist-numdots-en.png)
 
 1.  **List of buckets**
 

--- a/en/aws-compute-service/aws-security_groups.md
+++ b/en/aws-compute-service/aws-security_groups.md
@@ -1,8 +1,9 @@
 ---
-title: "Security groups"
-slug: aws-security-groups
+author: "AWS: Security groups"
+publisher: aws-security-groups
 ---
 
+# AWS: Security groups
 
 Security groups are sets of rule that provide control over network access to your resources in an AWS environment.
 
@@ -21,5 +22,5 @@ When deploying a new instance, the **Add instance** wizard presents three choice
     You can specify an IP address or a CIDR block, protocol, and port numbers to be allowed ingress. Enter a name and description for the security group, or accept the defaults, then enter the criteria for the group.
 
 
-**Parent topic:**[Networking](aws-networking.md)
+**Parent topic:**[AWS: Networking](aws-networking.md)
 

--- a/en/aws-compute-service/aws-security_groups.md
+++ b/en/aws-compute-service/aws-security_groups.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Security groups"
-publisher: aws-security-groups
+title: "AWS: Security groups"
+slug: aws-security-groups
 ---
 
-# AWS: Security groups
 
 Security groups are sets of rule that provide control over network access to your resources in an AWS environment.
 

--- a/en/aws-compute-service/aws-subnetworks.md
+++ b/en/aws-compute-service/aws-subnetworks.md
@@ -1,8 +1,9 @@
 ---
-title: "Subnetworks"
-slug: aws-subnetworks
+author: "AWS: Subnetworks"
+publisher: aws-subnetworks
 ---
 
+# AWS: Subnetworks
 
 A subnetwork is a portion of an AWS VPC that can be used to deploy instances. A single subnetwork may use a part of the IP range of its VPC, or it may use the VPC's full IP range.
 
@@ -12,5 +13,5 @@ The choice of subnetwork will determine the availability zone for an instance. T
 
 Subnetworks are found in the **Networking** tab of your AWS environment. Find the desired VPC and click on the **Subnetworks** feature to see a complete list.
 
-**Parent topic:**[Networking](aws-networking.md)
+**Parent topic:**[AWS: Networking](aws-networking.md)
 

--- a/en/aws-compute-service/aws-subnetworks.md
+++ b/en/aws-compute-service/aws-subnetworks.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Subnetworks"
-publisher: aws-subnetworks
+title: "AWS: Subnetworks"
+slug: aws-subnetworks
 ---
 
-# AWS: Subnetworks
 
 A subnetwork is a portion of an AWS VPC that can be used to deploy instances. A single subnetwork may use a part of the IP range of its VPC, or it may use the VPC's full IP range.
 

--- a/en/aws-compute-service/aws-volumes.md
+++ b/en/aws-compute-service/aws-volumes.md
@@ -1,8 +1,9 @@
 ---
-title: "Volumes"
-slug: aws-volumes
+author: "AWS: Volumes"
+publisher: aws-volumes
 ---
 
+# AWS: Volumes
 
 A volume on Amazon Web Services is where you can permanently store data for use with your instances. To an instance running on AWS, a volume is indistinguishable from a physical disk that is attached to the system. Volumes reside on infrastructure with a single availability zone, and can be attached only to instances within the same zone. The availability zone cannot be changed once a volume is provisioned.
 
@@ -18,5 +19,5 @@ Under some circumstances, a volume attached to an instance may be configured wit
 
 Volumes are listed under the **Compute** tab of your AWS environment, in the **Volumes** section.
 
-**Parent topic:**[Compute](aws-compute.md)
+**Parent topic:**[AWS: Compute](aws-compute.md)
 

--- a/en/aws-compute-service/aws-volumes.md
+++ b/en/aws-compute-service/aws-volumes.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Volumes"
-publisher: aws-volumes
+title: "AWS: Volumes"
+slug: aws-volumes
 ---
 
-# AWS: Volumes
 
 A volume on Amazon Web Services is where you can permanently store data for use with your instances. To an instance running on AWS, a volume is indistinguishable from a physical disk that is attached to the system. Volumes reside on infrastructure with a single availability zone, and can be attached only to instances within the same zone. The availability zone cannot be changed once a volume is provisioned.
 

--- a/en/aws-compute-service/aws-vpcs.md
+++ b/en/aws-compute-service/aws-vpcs.md
@@ -1,8 +1,9 @@
 ---
-title: "VPCs"
-slug: aws-vpcs
+author: "AWS: VPCs"
+publisher: aws-vpcs
 ---
 
+# AWS: VPCs
 
 A Virtual Private Cloud, referred to as a VPC, is a standard feature of cloud-based computing, and provides the underlying network structure where instances are deployed. A VPC is assigned an IP range, and can host one or more subnetworks within that range. Instances may then be created as needed within a subnetwork. See \[What is a VPC?\]\(../cloudstack-compute-service/what-is-a-vpc.md\) for general information on VPCs.
 
@@ -20,5 +21,5 @@ Before a VPC may be used to deploy instances, at least one subnetwork must be ad
 
 VPCs are listed under the **Networking** tab of your AWS environment, in the **VPC networks** section.
 
-**Parent topic:**[Networking](aws-networking.md)
+**Parent topic:**[AWS: Networking](aws-networking.md)
 

--- a/en/aws-compute-service/aws-vpcs.md
+++ b/en/aws-compute-service/aws-vpcs.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: VPCs"
-publisher: aws-vpcs
+title: "AWS: VPCs"
+slug: aws-vpcs
 ---
 
-# AWS: VPCs
 
 A Virtual Private Cloud, referred to as a VPC, is a standard feature of cloud-based computing, and provides the underlying network structure where instances are deployed. A VPC is assigned an IP range, and can host one or more subnetworks within that range. Instances may then be created as needed within a subnetwork. See \[What is a VPC?\]\(../cloudstack-compute-service/what-is-a-vpc.md\) for general information on VPCs.
 

--- a/en/aws-compute-service/aws_service_overview.md
+++ b/en/aws-compute-service/aws_service_overview.md
@@ -1,9 +1,8 @@
 ---
-author: "AWS: Service overview"
-publisher: aws-service-overview
+title: "AWS: Service overview"
+slug: aws-service-overview
 ---
 
-# AWS: Service overview
 
 ## Summary
 
@@ -20,7 +19,6 @@ The AWS platform is a public cloud, where customers can allocate resources to bu
 -   [Networking resources](aws-networking.md):
     -   [VPCs](aws-vpcs.md)
     -   [Subnetworks](aws-subnetworks.md)
-    -   [Elastic IPs](aws-elastic_ips.md)
 -   [Object storage resources](aws-object_storage.md)
 -   Kubernetes clusters
 

--- a/en/aws-compute-service/aws_service_overview.md
+++ b/en/aws-compute-service/aws_service_overview.md
@@ -1,8 +1,9 @@
 ---
-title: "Service overview"
-slug: aws-service-overview
+author: "AWS: Service overview"
+publisher: aws-service-overview
 ---
 
+# AWS: Service overview
 
 ## Summary
 
@@ -20,7 +21,7 @@ The AWS platform is a public cloud, where customers can allocate resources to bu
     -   [VPCs](aws-vpcs.md)
     -   [Subnetworks](aws-subnetworks.md)
     -   [Elastic IPs](aws-elastic_ips.md)
--   Object storage resources
+-   [Object storage resources](aws-object_storage.md)
 -   Kubernetes clusters
 
 Because CloudMC acts as a portal to AWS services, you may find that some operations appear to behave differently than when interacting with AWS directly. However, behind the scenes, all operations execute exactly as they normally would. Changes made to AWS entities in CloudMC will be reflected immediately in the actual resources.

--- a/layout.yaml
+++ b/layout.yaml
@@ -80,7 +80,7 @@ categories:
       - aws-buckets.md
       - aws-add_a_vpc.md
       - aws-add_a_subnetwork.md
-      - add_an_instance.md
+      - aws-add_an_instance.md
       - aws-add_a_volume.md
 - category: object-storage-service
   icon: fa fa-hdd-o


### PR DESCRIPTION
### Fixes [MC-20995](https://cloud-ops.atlassian.net/browse/MC-20995)

Added AWS: to all titles, pulled out unwanted reference to elsatic IPs.

[MC-20995]: https://cloudops.atlassian.net/browse/MC-20995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ